### PR TITLE
fix: aarch64 stability, semantic export, and scene-graph inference UX

### DIFF
--- a/environment-aarch64-cuda130.yml
+++ b/environment-aarch64-cuda130.yml
@@ -1,0 +1,22 @@
+# SimRecon：Linux aarch64（如 NVIDIA GB10 / Spark）+ 驅動內建 CUDA 13 環境
+# 與 PyTorch cu130 manylinux_2_28_aarch64 預編譯輪子對齊（需 conda-forge / Miniforge）。
+#
+#   conda env create -f environment-aarch64-cuda130.yml
+#   conda activate simrecon-aarch64
+#   bash install_cuda_extensions.sh
+#
+# 匯出鎖定清單（可選）：
+#   conda env export --no-builds > conda-lock-aarch64.yml
+#
+name: simrecon-aarch64
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - setuptools>=61
+  - wheel
+  - cmake
+  - ninja
+  - pip:
+      - -r requirements-aarch64-conda-pip.txt

--- a/infer_scene_graph.py
+++ b/infer_scene_graph.py
@@ -24,11 +24,18 @@ import json
 import os
 import re
 from pathlib import Path
+from threading import Thread
 from typing import Any, Dict, List, Optional, Tuple
 
 import torch
 from PIL import Image
-from transformers import AutoModelForImageTextToText, AutoProcessor
+from tqdm import tqdm
+from transformers import AutoModelForImageTextToText, AutoProcessor, TextIteratorStreamer
+
+
+def _log(msg: str) -> None:
+    """與 tqdm 並用時不衝破進度條。"""
+    tqdm.write(str(msg))
 
 
 def load_model(model_path: str = "Qwen/Qwen3-VL-8B-Thinking"):
@@ -73,7 +80,9 @@ def infer_objects_and_relations(
     processor,
     image_path: str,
     object_ids: List[int],
-) -> Dict[str, Any]:
+    max_new_tokens: int = 32768,
+    stream_progress: bool = True,
+) -> str:
     """
     Use Qwen3-VL to infer object categories and support relations for each ID in the image.
     
@@ -84,7 +93,7 @@ def infer_objects_and_relations(
         object_ids: List of object IDs in the image
     
     Returns:
-        Inference result dictionary
+        模型完整輸出字串（含 Thinking 推理與 JSON）
     """
     # Convert ID to display ID (id + 3)
     display_ids = [oid + 3 for oid in object_ids]
@@ -169,17 +178,50 @@ Now analyze the image and output the complete JSON with all {num_objects} object
     )
     inputs = inputs.to(model.device)
 
+    _log(
+        f"  VLM 生成中（Qwen3-VL-Thinking 常先輸出長篇推理，max_new_tokens={max_new_tokens}，單幀數分鐘屬正常）..."
+    )
+
     with torch.no_grad():
-        generated_ids = model.generate(**inputs, max_new_tokens=32768)  # Increase length limit to support multi-object output
-    
+        if stream_progress:
+            try:
+                tokenizer = getattr(processor, "tokenizer", None)
+                if tokenizer is None:
+                    raise RuntimeError("processor 無 tokenizer，無法串流進度")
+                streamer = TextIteratorStreamer(
+                    tokenizer, skip_prompt=True, skip_special_tokens=True
+                )
+                gen_kwargs = {**dict(inputs), "max_new_tokens": max_new_tokens, "streamer": streamer}
+
+                def _run_generate() -> None:
+                    with torch.no_grad():
+                        model.generate(**gen_kwargs)
+
+                thread = Thread(target=_run_generate)
+                thread.start()
+                chunks: List[str] = []
+                for piece in tqdm(
+                    streamer,
+                    desc="  generating",
+                    leave=False,
+                    unit="chunk",
+                ):
+                    chunks.append(piece)
+                thread.join()
+                return "".join(chunks)
+            except Exception as e:
+                _log(f"  串流進度不可用（{e}），改為一次性 generate。")
+
+        generated_ids = model.generate(**inputs, max_new_tokens=max_new_tokens)
+
     generated_ids_trimmed = [
-        out_ids[len(in_ids):] 
+        out_ids[len(in_ids):]
         for in_ids, out_ids in zip(inputs.input_ids, generated_ids)
     ]
     output_text = processor.batch_decode(
-        generated_ids_trimmed, 
-        skip_special_tokens=True, 
-        clean_up_tokenization_spaces=False
+        generated_ids_trimmed,
+        skip_special_tokens=True,
+        clean_up_tokenization_spaces=False,
     )[0]
 
     return output_text
@@ -542,48 +584,55 @@ def process_single_frame(
     id_scene_path: str,
     output_dir: str,
     frame_name: str,
+    max_new_tokens: int = 32768,
+    stream_progress: bool = True,
 ) -> Optional[Dict[str, Any]]:
     """Process single frame and save results."""
-    print(f"\n{'='*60}")
-    print(f"Processing frame: {frame_name}")
-    print(f"Input: {id_scene_path}")
-    
+    _log(f"\n{'='*60}")
+    _log(f"Processing frame: {frame_name}")
+    _log(f"Input: {id_scene_path}")
+
     # Extract all instance IDs in this frame
     object_ids = extract_ids_from_image_name(id_scene_path)
-    print(f"Detected object IDs (instance_id): {object_ids}")
-    print(f"Display IDs (instance_id + 3): {[oid + 3 for oid in object_ids]}")
-    
+    _log(f"Detected object IDs (instance_id): {object_ids}")
+    _log(f"Display IDs (instance_id + 3): {[oid + 3 for oid in object_ids]}")
+
     if not object_ids:
-        print("No objects found in this frame. Skipping.")
+        _log("No objects found in this frame. Skipping.")
         return None
-    
+
     # Inference
-    print("Running inference...")
+    _log("Running inference...")
     raw_output = infer_objects_and_relations(
-        model, processor, id_scene_path, object_ids
+        model,
+        processor,
+        id_scene_path,
+        object_ids,
+        max_new_tokens=max_new_tokens,
+        stream_progress=stream_progress,
     )
-    
-    print("\n--- Model Raw Output ---")
-    print(raw_output[:500] + "..." if len(raw_output) > 500 else raw_output)
-    print("--- End of Raw Output ---\n")
-    
+
+    _log("\n--- Model Raw Output ---")
+    _log(raw_output[:500] + "..." if len(raw_output) > 500 else raw_output)
+    _log("--- End of Raw Output ---\n")
+
     # Parse output
     parsed_result = parse_model_output(raw_output)
-    
+
     # Post-processing: filter, deduplicate, correct physical errors
     display_ids = [oid + 3 for oid in object_ids]
     if parsed_result.get("objects"):
-        print(f"Before post-processing: {len(parsed_result['objects'])} objects")
+        _log(f"Before post-processing: {len(parsed_result['objects'])} objects")
         parsed_result["objects"] = post_process_objects(parsed_result["objects"], display_ids)
-        print(f"After post-processing: {len(parsed_result['objects'])} objects")
+        _log(f"After post-processing: {len(parsed_result['objects'])} objects")
     
     # Build scene graph
     scene_graph = build_scene_graph(parsed_result)
     
     # Generate text visualization
     text_viz = visualize_scene_graph_text(scene_graph)
-    print(text_viz)
-    
+    _log(text_viz)
+
     # Save results
     # 1. JSON format
     json_path = os.path.join(output_dir, f"{frame_name}.json")
@@ -595,18 +644,18 @@ def process_single_frame(
     }
     with open(json_path, 'w', encoding='utf-8') as f:
         json.dump(result_data, f, indent=2, ensure_ascii=False)
-    print(f"Saved: {json_path}")
-    
+    _log(f"Saved: {json_path}")
+
     # 2. HTML visualization
     html_path = os.path.join(output_dir, f"{frame_name}.html")
     generate_scene_graph_html(scene_graph, html_path)
-    print(f"Saved: {html_path}")
-    
+    _log(f"Saved: {html_path}")
+
     # 3. Text format
     txt_path = os.path.join(output_dir, f"{frame_name}.txt")
     with open(txt_path, 'w', encoding='utf-8') as f:
         f.write(text_viz)
-    print(f"Saved: {txt_path}")
+    _log(f"Saved: {txt_path}")
     
     return result_data
 
@@ -637,7 +686,18 @@ def main():
         default="Qwen/Qwen3-VL-8B-Thinking",
         help="Qwen3-VL model name or path",
     )
-    
+    parser.add_argument(
+        "--max_new_tokens",
+        type=int,
+        default=32768,
+        help="單次生成上限（物體多時勿過低；預設 32768）",
+    )
+    parser.add_argument(
+        "--no_stream_progress",
+        action="store_true",
+        help="關閉生成串流進度條（除錯或與舊版 transformers 不相容時使用）",
+    )
+
     args = parser.parse_args()
     
     # Determine run mode
@@ -667,7 +727,15 @@ def main():
         os.makedirs(output_dir, exist_ok=True)
         print(f"Output dir: {output_dir}")
         
-        process_single_frame(model, processor, args.id_scene_path, output_dir, frame_name)
+        process_single_frame(
+            model,
+            processor,
+            args.id_scene_path,
+            output_dir,
+            frame_name,
+            max_new_tokens=args.max_new_tokens,
+            stream_progress=not args.no_stream_progress,
+        )
         
     else:
         # ========== Batch mode ==========
@@ -690,24 +758,35 @@ def main():
             if os.path.isdir(os.path.join(instance_project_dir, d))
         ])
         
-        print(f"Found {len(frame_dirs)} frames to process")
-        
-        all_results = {}
-        for frame_name in frame_dirs:
+        pending = []
+        for frame_name in sorted(frame_dirs):
             id_scene_path = os.path.join(instance_project_dir, frame_name, "id_scene.png")
-            
             if not os.path.exists(id_scene_path):
-                print(f"Warning: id_scene.png not found in {frame_name}, skipping")
+                _log(f"Warning: id_scene.png not found in {frame_name}, skipping")
                 continue
-            
+            pending.append((frame_name, id_scene_path))
+
+        _log(f"Found {len(frame_dirs)} frame directories, {len(pending)} with id_scene.png")
+
+        all_results = {}
+        for frame_name, id_scene_path in tqdm(
+            pending,
+            desc="Scene graph inference",
+            unit="frame",
+        ):
             result = process_single_frame(
-                model, processor, id_scene_path, output_dir, frame_name
+                model,
+                processor,
+                id_scene_path,
+                output_dir,
+                frame_name,
+                max_new_tokens=args.max_new_tokens,
+                stream_progress=not args.no_stream_progress,
             )
-            
+
             if result:
                 all_results[frame_name] = result
-            
-            # Clear GPU memory
+
             torch.cuda.empty_cache()
         
         # Save summary results

--- a/install_cuda_extensions.sh
+++ b/install_cuda_extensions.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# 在 conda env create 完成且已 conda activate、PyTorch 已裝好後執行。
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$ROOT"
+
+# conda / 系統有時帶入 -Werror，PyTorch 2.x 標頭會觸發大量 deprecated 警告而導致 ninja 失敗
+if [[ "${CFLAGS:-}" == *-Werror* ]] || [[ "${CXXFLAGS:-}" == *-Werror* ]]; then
+  echo "[install_cuda_extensions] 偵測到 CFLAGS/CXXFLAGS 含 -Werror，已暫時 unset（避免擴充編譯失敗）"
+  unset CFLAGS CXXFLAGS
+fi
+
+PY=python3
+command -v "${PY}" >/dev/null 2>&1 || PY=python
+
+if [[ -z "${TORCH_CUDA_ARCH_LIST:-}" ]]; then
+  export TORCH_CUDA_ARCH_LIST="$("${PY}" - <<'PY'
+import torch
+if torch.cuda.is_available():
+    major, minor = torch.cuda.get_device_capability()
+    print(f"{major}.{minor}")
+else:
+    print("12.1")
+PY
+)"
+  echo "[install_cuda_extensions] TORCH_CUDA_ARCH_LIST=${TORCH_CUDA_ARCH_LIST}"
+fi
+
+pip install --no-build-isolation -e submodules/diff-surfel-rasterization
+pip install --no-build-isolation submodules/simple-knn

--- a/requirements-aarch64-conda-pip.txt
+++ b/requirements-aarch64-conda-pip.txt
@@ -1,0 +1,7 @@
+# conda env create 用：--extra-index-url 須與 URL 同一行。
+# CUDA 擴充勿列於此；環境建立後執行 ./install_cuda_extensions.sh
+--extra-index-url https://download.pytorch.org/whl/cu130
+torch==2.10.0+cu130
+torchvision==0.25.0+cu130
+torchaudio==2.10.0+cu130
+-r requirements-aarch64-pypi-only.txt

--- a/requirements-aarch64-native.txt
+++ b/requirements-aarch64-native.txt
@@ -1,0 +1,3 @@
+# diff-surfel-rasterization / simple-knn 的 setup.py 會 import torch；須使用 --no-build-isolation（見 install_cuda_extensions.sh）。
+-e submodules/diff-surfel-rasterization
+submodules/simple-knn

--- a/requirements-aarch64-pypi-only.txt
+++ b/requirements-aarch64-pypi-only.txt
@@ -1,0 +1,21 @@
+# 不含需在 setup.py 階段 import torch 的 CUDA 擴充（見 requirements-aarch64-native.txt）。
+# 原 requirements.txt 中 numpy==1.24.4 與 PyTorch 2.10 / NumPy 2.x 生態較難並存，aarch64 放寬為相容區間。
+
+plyfile
+tqdm
+# aarch64：PyPI 僅提供 dearpygui 2.3.x（無 1.11.1）；與 x86 requirements.txt 的 1.11.1 分流。
+dearpygui==2.3.1
+opencv-python
+pillow
+scikit-learn
+joblib
+numpy>=1.26,<2.3
+open3d>=0.16.0
+matplotlib
+trimesh
+lpips
+e3nn
+einops
+einsum
+kornia
+pyrender

--- a/requirements-aarch64.txt
+++ b/requirements-aarch64.txt
@@ -1,0 +1,27 @@
+# aarch64 完整手動安裝時：先裝 PyTorch（cu130），再：
+#   pip install -r requirements-aarch64-pypi-only.txt
+#   pip install --no-build-isolation -r requirements-aarch64-native.txt
+# 或使用 conda 時：conda env create 後執行 ./install_cuda_extensions.sh
+#
+# 以下為「舊版單檔」聚合（仍可用，但 conda 請改用 requirements-aarch64-conda-pip.txt）
+
+plyfile
+tqdm
+dearpygui==2.3.1
+opencv-python
+pillow
+scikit-learn
+joblib
+numpy>=1.26,<2.3
+open3d>=0.16.0
+matplotlib
+trimesh
+lpips
+e3nn
+einops
+einsum
+kornia
+pyrender
+
+-e submodules/diff-surfel-rasterization
+submodules/simple-knn

--- a/scene/gaussian_model.py
+++ b/scene/gaussian_model.py
@@ -11,6 +11,7 @@
 
 import torch
 import numpy as np
+import platform
 from utils.general_utils import inverse_sigmoid, get_expon_lr_func, build_rotation
 from torch import nn
 import os
@@ -27,6 +28,60 @@ from scipy.spatial.transform import Rotation
 from e3nn import o3
 import einops
 import einsum
+
+
+def _should_export_open3d_auxiliary_plys() -> bool:
+    """主 PLY 已由 plyfile 寫入；*_color.ply / *_feat.ply 僅供視覺化。部分 aarch64 Open3D 會在
+    Vector3dVector / write_point_cloud 路徑 SIGSEGV，預設在 arm64 上跳過。"""
+    v = os.environ.get("SIMRECON_OPEN3D_AUX_PLY", "").strip().lower()
+    if v in ("1", "true", "yes"):
+        return True
+    if v in ("0", "false", "no"):
+        return False
+    return platform.machine() not in ("aarch64", "arm64")
+
+
+def _write_open3d_auxiliary_plys(path: str, xyz: np.ndarray, f_dc: np.ndarray, seg_feat: np.ndarray | None) -> None:
+    if not _should_export_open3d_auxiliary_plys():
+        return
+    try:
+        o3d_pointcloud = o3d.geometry.PointCloud()
+        o3d_pointcloud.points = o3d.utility.Vector3dVector(xyz)
+        o3d_pointcloud.colors = o3d.utility.Vector3dVector(SH2RGB(f_dc).clip(0.0, 1.0))
+        o3d.io.write_point_cloud(path.split(".")[0] + "_color.ply", o3d_pointcloud)
+        if seg_feat is not None:
+            o3d_pointcloud.colors = o3d.utility.Vector3dVector(feature3d_to_rgb(seg_feat))
+            o3d.io.write_point_cloud(path.split(".")[0] + "_feat.ply", o3d_pointcloud)
+    except Exception as e:
+        print(f"⚠️ Open3D auxiliary PLY export skipped/failed ({e}); main PLY is already saved.")
+
+
+def _write_xyz_rgb_ply(path: str, xyz: np.ndarray, colors: np.ndarray) -> None:
+    """以 plyfile 寫入帶 uchar 頂點色的 PLY（避開 Open3D IO）。colors: (N,3) float [0,1]。"""
+    xyz = np.asarray(xyz, dtype=np.float32)
+    colors = np.clip(np.asarray(colors, dtype=np.float64), 0.0, 1.0)
+    rgb = (colors * 255.0 + 0.5).astype(np.uint8)
+    n = int(xyz.shape[0])
+    if n == 0:
+        return
+    verts = np.empty(
+        n,
+        dtype=[
+            ("x", "f4"),
+            ("y", "f4"),
+            ("z", "f4"),
+            ("red", "u1"),
+            ("green", "u1"),
+            ("blue", "u1"),
+        ],
+    )
+    verts["x"] = xyz[:, 0]
+    verts["y"] = xyz[:, 1]
+    verts["z"] = xyz[:, 2]
+    verts["red"] = rgb[:, 0]
+    verts["green"] = rgb[:, 1]
+    verts["blue"] = rgb[:, 2]
+    PlyData([PlyElement.describe(verts, "vertex")]).write(path)
 
 
 class GaussianModel:
@@ -379,13 +434,8 @@ class GaussianModel:
         el = PlyElement.describe(elements, 'vertex')
         PlyData([el]).write(path)
 
-        o3d_pointcloud = o3d.geometry.PointCloud()
-        o3d_pointcloud.points = o3d.utility.Vector3dVector(xyz)
-        o3d_pointcloud.colors = o3d.utility.Vector3dVector(SH2RGB(f_dc).clip(0., 1.))
-        o3d.io.write_point_cloud(path.split(".")[0] + "_color.ply", o3d_pointcloud)
-        if self._seg_feature is not None:
-            o3d_pointcloud.colors = o3d.utility.Vector3dVector(feature3d_to_rgb(seg_feat))
-            o3d.io.write_point_cloud(path.split(".")[0] + "_feat.ply", o3d_pointcloud)
+        seg_feat_arg = seg_feat if self._seg_feature is not None else None
+        _write_open3d_auxiliary_plys(path, xyz, f_dc, seg_feat_arg)
 
     def save_ply_as_3dgs(self, path):
         """
@@ -418,13 +468,8 @@ class GaussianModel:
         el = PlyElement.describe(elements, 'vertex')
         PlyData([el]).write(path)
 
-        o3d_pointcloud = o3d.geometry.PointCloud()
-        o3d_pointcloud.points = o3d.utility.Vector3dVector(xyz)
-        o3d_pointcloud.colors = o3d.utility.Vector3dVector(SH2RGB(f_dc).clip(0., 1.))
-        o3d.io.write_point_cloud(path.split(".")[0] + "_color.ply", o3d_pointcloud)
-        if self._seg_feature is not None:
-            o3d_pointcloud.colors = o3d.utility.Vector3dVector(feature3d_to_rgb(seg_feat))
-            o3d.io.write_point_cloud(path.split(".")[0] + "_feat.ply", o3d_pointcloud)
+        seg_feat_arg = seg_feat if self._seg_feature is not None else None
+        _write_open3d_auxiliary_plys(path, xyz, f_dc, seg_feat_arg)
 
     def reset_opacity(self):
         """

--- a/spatial_track/modules/node.py
+++ b/spatial_track/modules/node.py
@@ -1,3 +1,4 @@
+import numpy as np
 import torch
 import open3d as o3d
 
@@ -55,17 +56,15 @@ class Node:
     
     def get_point_cloud(self, scene_points):
         '''
-            将当前节点对应的3D点坐标提取为Open3D点云对象，便于可视化与后处理。
+            将当前节点对应的3D点坐标提取为 numpy（避免 linux-aarch64 上 Open3D Vector3dVector / select_by_index SIGSEGV）。
 
             参数：
             - scene_points: (N_points, 3) 的全局点坐标数组（与 point_ids 对应）
 
             返回：
-            - pcld: open3d.geometry.PointCloud 对象（只包含该节点的点）
-            - point_ids: list[int] 该节点对应的3D点ID列表
+            - points: (K, 3) float64 C-contiguous
+            - point_ids: (K,) int64，与 points 行一一对应
         '''
-        point_ids = list(self.point_ids)
-        points = scene_points[point_ids]
-        pcld = o3d.geometry.PointCloud()
-        pcld.points = o3d.utility.Vector3dVector(points)
-        return pcld, point_ids
+        point_ids = np.array(list(self.point_ids), dtype=np.int64)
+        points = np.ascontiguousarray(np.asarray(scene_points[point_ids], dtype=np.float64))
+        return points, point_ids

--- a/spatial_track/modules/post_process.py
+++ b/spatial_track/modules/post_process.py
@@ -1,9 +1,8 @@
 import numpy as np
-
-import numpy as np
 import os
 import torch
 from tqdm import tqdm
+from sklearn.cluster import DBSCAN
 
 
 def judge_bbox_overlay(bbox_1, bbox_2):
@@ -69,10 +68,10 @@ def merge_overlapping_objects(total_point_ids_list, total_bbox_list, total_mask_
     return valid_point_ids_list, valid_pcld_mask_list, invalid_object
 
 
-def filter_point(point_frame_matrix, node, pcld_list, point_ids_list, mask_point_clouds, args):
+def filter_point(point_frame_matrix, node, scene_points, point_ids_list, mask_point_clouds, args):
     '''
         点过滤（参考 OVIR-3D）：
-        - 对每个DBSCAN分割得到的子对象（pcld_list/point_ids_list），计算点的检测比率：
+        - 对每个DBSCAN分割得到的子对象（point_ids_list），计算点的检测比率：
           检测比率 = 该点在该节点（cluster）出现的帧数 / 该点在全视频出现的帧数
         - 若检测比率 > 阈值（args.point_filter_threshold），则保留；否则过滤
         - 同时统计每个mask在其隶属对象中的覆盖率，用于后续（如OpenMask3D）
@@ -80,7 +79,7 @@ def filter_point(point_frame_matrix, node, pcld_list, point_ids_list, mask_point
         参数：
         - point_frame_matrix: (N_pts, N_frames) 布尔矩阵，点在帧中是否出现
         - node: 当前聚类节点（包含 mask_list 与 visible_frame）
-        - pcld_list: List[o3d.geometry.PointCloud]，DBSCAN分割出的子点云
+        - scene_points: (N_points, 3) 全局坐标，用于子对象 AABB
         - point_ids_list: List[np.ndarray]，对应子点云的点ID列表
         - mask_point_clouds: {f"frameId_maskId": set(point_ids)}，每个掩码的点集合
         - args: 聚类与过滤阈值，其中 point_filter_threshold 使用
@@ -161,41 +160,43 @@ def filter_point(point_frame_matrix, node, pcld_list, point_ids_list, mask_point
         if len(valid_point_ids) == 0 or len(object_mask_list[i]) < 2:
             continue
         filtered_point_ids.append(point_ids_list[i][valid_point_ids])
-        filtered_bbox_list.append([np.amin(pcld_list[i].points, axis=0), np.amax(pcld_list[i].points, axis=0)])
+        pid = point_ids_list[i][valid_point_ids]
+        coords = scene_points[pid]
+        filtered_bbox_list.append([np.amin(coords, axis=0), np.amax(coords, axis=0)])
         filtered_mask_list.append(object_mask_list[i])
     return filtered_point_ids, filtered_bbox_list, filtered_mask_list
 
 
-def dbscan_process(pcld, point_ids, DBSCAN_THRESHOLD=0.1, min_points=4):
+def dbscan_process(points, point_ids, DBSCAN_THRESHOLD=0.1, min_points=4):
     '''
     使用 DBSCAN 将不连通的点云拆分为多个对象（参考 OVIR-3D）。
+    全程 numpy + sklearn，避免 Open3D 在 aarch64 上 SIGSEGV。
 
     参数：
-    - pcld: o3d.geometry.PointCloud 当前节点的点云
-    - point_ids: 对应全局点的ID
+    - points: (K, 3) 点坐标
+    - point_ids: (K,) 与 points 行对应的全局点 ID
     - DBSCAN_THRESHOLD: eps半径
     - min_points: 最小点数阈值
 
     返回：
-    - pcld_list: 拆分后的子点云列表
-    - point_ids_list: 对应子点云的点ID数组列表
+    - point_ids_list: 每个子簇的全局点 ID 数组列表
     '''
-    # TODO: 可以考虑融合CLIP特征提升一致性
-    labels = np.array(pcld.cluster_dbscan(eps=DBSCAN_THRESHOLD, min_points=min_points)) + 1  # -1为噪声
+    pts = np.ascontiguousarray(np.asarray(points, dtype=np.float64))
+    pcld_ids_list = np.asarray(point_ids)
+    if pts.shape[0] == 0:
+        return []
+
+    clustering = DBSCAN(eps=DBSCAN_THRESHOLD, min_samples=min_points, n_jobs=1).fit(pts)
+    labels = clustering.labels_.astype(np.int64) + 1
     count = np.bincount(labels)
 
-    # 将不连通的点云拆分成多个对象
-    pcld_list, point_ids_list = [], []
-    pcld_ids_list = np.array(point_ids)
+    point_ids_list = []
     for i in range(len(count)):
         remain_index = np.where(labels == i)[0]
         if len(remain_index) == 0:
             continue
-        new_pcld = pcld.select_by_index(remain_index)
-        point_ids = pcld_ids_list[remain_index]
-        pcld_list.append(new_pcld)
-        point_ids_list.append(point_ids)
-    return pcld_list, point_ids_list
+        point_ids_list.append(pcld_ids_list[remain_index])
+    return point_ids_list
 
 
 def find_represent_mask(mask_info_list):
@@ -292,13 +293,13 @@ def post_process(gaussian, mask_assocation, clustering_args):
     for node in iterator:
         if len(node.mask_list) < 2:  # objects merged from less than 2 masks are ignored
             continue
-        pcld, point_ids = node.get_point_cloud(scene_points)
+        points_np, point_ids = node.get_point_cloud(scene_points)
         if True:
-            pcld_list, point_ids_list = dbscan_process(pcld, point_ids, DBSCAN_THRESHOLD=0.1,
-                                                       min_points=4)  # split the disconnected point cloud into different objects
+            point_ids_list = dbscan_process(points_np, point_ids, DBSCAN_THRESHOLD=0.1,
+                                            min_points=4)
         else:
-            pcld_list, point_ids_list = [pcld], [np.array(point_ids)]
-        point_ids_list, bbox_list, mask_list = filter_point(gaussian_in_frame_matrix, node, pcld_list,
+            point_ids_list = [np.asarray(point_ids)]
+        point_ids_list, bbox_list, mask_list = filter_point(gaussian_in_frame_matrix, node, scene_points,
                                                             point_ids_list,
                                                             mask_gaussian_pclds,
                                                             clustering_args)

--- a/submodules/diff-surfel-rasterization/cuda_rasterizer/backward.h
+++ b/submodules/diff-surfel-rasterization/cuda_rasterizer/backward.h
@@ -12,6 +12,7 @@
 #ifndef CUDA_RASTERIZER_BACKWARD_H_INCLUDED
 #define CUDA_RASTERIZER_BACKWARD_H_INCLUDED
 
+#include <cstdint>
 #include <cuda.h>
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"

--- a/submodules/diff-surfel-rasterization/cuda_rasterizer/forward.h
+++ b/submodules/diff-surfel-rasterization/cuda_rasterizer/forward.h
@@ -12,6 +12,7 @@
 #ifndef CUDA_RASTERIZER_FORWARD_H_INCLUDED
 #define CUDA_RASTERIZER_FORWARD_H_INCLUDED
 
+#include <cstdint>
 #include <cuda.h>
 #include "cuda_runtime.h"
 #include "device_launch_parameters.h"

--- a/submodules/diff-surfel-rasterization/cuda_rasterizer/rasterizer_impl.cu
+++ b/submodules/diff-surfel-rasterization/cuda_rasterizer/rasterizer_impl.cu
@@ -10,6 +10,7 @@
  */
 
 #include "rasterizer_impl.h"
+#include <cstdint>
 #include <iostream>
 #include <fstream>
 #include <algorithm>

--- a/submodules/diff-surfel-rasterization/cuda_rasterizer/rasterizer_impl.h
+++ b/submodules/diff-surfel-rasterization/cuda_rasterizer/rasterizer_impl.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <vector>
 #include "rasterizer.h"
@@ -37,8 +38,8 @@ namespace CudaRasterizer
 		float* transMat;
 		float4* normal_opacity;
 		float* rgb;
-		uint32_t* point_offsets;
-		uint32_t* tiles_touched;
+		std::uint32_t* point_offsets;
+		std::uint32_t* tiles_touched;
 
 		static GeometryState fromChunk(char*& chunk, size_t P);
 	};
@@ -46,7 +47,7 @@ namespace CudaRasterizer
 	struct ImageState
 	{
 		uint2* ranges;
-		uint32_t* n_contrib;
+		std::uint32_t* n_contrib;
 		float* accum_alpha;
 
 		static ImageState fromChunk(char*& chunk, size_t N);
@@ -55,10 +56,10 @@ namespace CudaRasterizer
 	struct BinningState
 	{
 		size_t sorting_size;
-		uint64_t* point_list_keys_unsorted;
-		uint64_t* point_list_keys;
-		uint32_t* point_list_unsorted;
-		uint32_t* point_list;
+		std::uint64_t* point_list_keys_unsorted;
+		std::uint64_t* point_list_keys;
+		std::uint32_t* point_list_unsorted;
+		std::uint32_t* point_list;
 		char* list_sorting_space;
 
 		static BinningState fromChunk(char*& chunk, size_t P);

--- a/submodules/diff-surfel-rasterization/rasterize_points.cu
+++ b/submodules/diff-surfel-rasterization/rasterize_points.cu
@@ -25,7 +25,7 @@
 #include <functional>
 
 #define CHECK_INPUT(x)											\
-	AT_ASSERTM(x.type().is_cuda(), #x " must be a CUDA tensor")
+	AT_ASSERTM(x.is_cuda(), #x " must be a CUDA tensor")
 	// AT_ASSERTM(x.is_contiguous(), #x " must be contiguous")
 
 std::function<char*(size_t N)> resizeFunctional(torch::Tensor& t) {
@@ -122,29 +122,29 @@ RasterizeGaussiansCUDA(
 		binningFunc,
 		imgFunc,
 		P, degree, M, F,
-		background.contiguous().data<float>(),
+		background.contiguous().data_ptr<float>(),
 		W, H,
-		means3D.contiguous().data<float>(),
+		means3D.contiguous().data_ptr<float>(),
 		sh.contiguous().data_ptr<float>(),
-		colors.contiguous().data<float>(), 
-		opacity.contiguous().data<float>(), 
+		colors.contiguous().data_ptr<float>(), 
+		opacity.contiguous().data_ptr<float>(), 
 		scales.contiguous().data_ptr<float>(),
 		scale_modifier,
 		rotations.contiguous().data_ptr<float>(),
-		transMat_precomp.contiguous().data<float>(),
-        extra_attrs.contiguous().data<float>(), // note
-		viewmatrix.contiguous().data<float>(), 
-		projmatrix.contiguous().data<float>(),
-		campos.contiguous().data<float>(),
+		transMat_precomp.contiguous().data_ptr<float>(),
+        extra_attrs.contiguous().data_ptr<float>(), // note
+		viewmatrix.contiguous().data_ptr<float>(), 
+		projmatrix.contiguous().data_ptr<float>(),
+		campos.contiguous().data_ptr<float>(),
 		tan_fovx,
 		tan_fovy,
 		prefiltered,
-		out_color.contiguous().data<float>(),
-		out_others.contiguous().data<float>(),
-        out_extra.contiguous().data<float>(), // note
-        gau_related_pixels.contiguous().data<int>(),
-        gau_pixel_indices.data<int>(),
-		radii.contiguous().data<int>(),
+		out_color.contiguous().data_ptr<float>(),
+		out_others.contiguous().data_ptr<float>(),
+        out_extra.contiguous().data_ptr<float>(), // note
+        gau_related_pixels.contiguous().data_ptr<int>(),
+        gau_pixel_indices.data_ptr<int>(),
+		radii.contiguous().data_ptr<int>(),
 		debug);
   }
   return std::make_tuple(rendered, out_color, out_others, radii,out_extra, geomBuffer, binningBuffer, imgBuffer, gau_related_pixels, gau_pixel_indices);
@@ -223,38 +223,38 @@ std::tuple<torch::Tensor, torch::Tensor, torch::Tensor, torch::Tensor, torch::Te
   if(P != 0)
   {  
 	  CudaRasterizer::Rasterizer::backward(P, degree, M, R, F,
-	  background.contiguous().data<float>(),
+	  background.contiguous().data_ptr<float>(),
 	  W, H, 
-	  means3D.contiguous().data<float>(),
-	  sh.contiguous().data<float>(),
-	  colors.contiguous().data<float>(),
+	  means3D.contiguous().data_ptr<float>(),
+	  sh.contiguous().data_ptr<float>(),
+	  colors.contiguous().data_ptr<float>(),
 	  scales.data_ptr<float>(),
 	  scale_modifier,
 	  rotations.data_ptr<float>(),
-	  transMat_precomp.contiguous().data<float>(),
-      extra_attrs.contiguous().data<float>(),
-	  viewmatrix.contiguous().data<float>(),
-	  projmatrix.contiguous().data<float>(),
-	  campos.contiguous().data<float>(),
+	  transMat_precomp.contiguous().data_ptr<float>(),
+      extra_attrs.contiguous().data_ptr<float>(),
+	  viewmatrix.contiguous().data_ptr<float>(),
+	  projmatrix.contiguous().data_ptr<float>(),
+	  campos.contiguous().data_ptr<float>(),
 	  tan_fovx,
 	  tan_fovy,
-	  radii.contiguous().data<int>(),
+	  radii.contiguous().data_ptr<int>(),
 	  reinterpret_cast<char*>(geomBuffer.contiguous().data_ptr()),
 	  reinterpret_cast<char*>(binningBuffer.contiguous().data_ptr()),
 	  reinterpret_cast<char*>(imageBuffer.contiguous().data_ptr()),
-	  dL_dout_color.contiguous().data<float>(),
-	  dL_dout_others.contiguous().data<float>(),
-      dL_dout_extra.contiguous().data<float>(),
-	  dL_dmeans2D.contiguous().data<float>(),
-	  dL_dnormal.contiguous().data<float>(),  
-	  dL_dopacity.contiguous().data<float>(),
-	  dL_dcolors.contiguous().data<float>(),
-	  dL_dmeans3D.contiguous().data<float>(),
-	  dL_dtransMat.contiguous().data<float>(),
-	  dL_dsh.contiguous().data<float>(),
-	  dL_dscales.contiguous().data<float>(),
-	  dL_drotations.contiguous().data<float>(),
-      dL_dextra_attrs.contiguous().data<float>(),
+	  dL_dout_color.contiguous().data_ptr<float>(),
+	  dL_dout_others.contiguous().data_ptr<float>(),
+      dL_dout_extra.contiguous().data_ptr<float>(),
+	  dL_dmeans2D.contiguous().data_ptr<float>(),
+	  dL_dnormal.contiguous().data_ptr<float>(),  
+	  dL_dopacity.contiguous().data_ptr<float>(),
+	  dL_dcolors.contiguous().data_ptr<float>(),
+	  dL_dmeans3D.contiguous().data_ptr<float>(),
+	  dL_dtransMat.contiguous().data_ptr<float>(),
+	  dL_dsh.contiguous().data_ptr<float>(),
+	  dL_dscales.contiguous().data_ptr<float>(),
+	  dL_drotations.contiguous().data_ptr<float>(),
+      dL_dextra_attrs.contiguous().data_ptr<float>(),
 	  debug);
   }
 
@@ -273,10 +273,10 @@ torch::Tensor markVisible(
   if(P != 0)
   {
 	CudaRasterizer::Rasterizer::markVisible(P,
-		means3D.contiguous().data<float>(),
-		viewmatrix.contiguous().data<float>(),
-		projmatrix.contiguous().data<float>(),
-		present.contiguous().data<bool>());
+		means3D.contiguous().data_ptr<float>(),
+		viewmatrix.contiguous().data_ptr<float>(),
+		projmatrix.contiguous().data_ptr<float>(),
+		present.contiguous().data_ptr<bool>());
   }
   
   return present;

--- a/submodules/diff-surfel-rasterization/setup.py
+++ b/submodules/diff-surfel-rasterization/setup.py
@@ -12,7 +12,9 @@
 from setuptools import setup
 from torch.utils.cpp_extension import CUDAExtension, BuildExtension
 import os
-os.path.dirname(os.path.abspath(__file__))
+
+_glm_inc = "-I" + os.path.join(os.path.dirname(os.path.abspath(__file__)), "third_party/glm/")
+_warn_suppress = ["-Wno-deprecated-declarations"]
 
 setup(
     name="diff_surfel_rasterization",
@@ -27,7 +29,10 @@ setup(
             "cuda_rasterizer/backward.cu",
             "rasterize_points.cu",
             "ext.cpp"],
-            extra_compile_args={"nvcc": ["-I" + os.path.join(os.path.dirname(os.path.abspath(__file__)), "third_party/glm/")]})
+            extra_compile_args={
+                "cxx": _warn_suppress,
+                "nvcc": [_glm_inc, "-Xcompiler=" + ",".join(_warn_suppress)],
+            })
         ],
     cmdclass={
         'build_ext': BuildExtension

--- a/submodules/simple-knn/setup.py
+++ b/submodules/simple-knn/setup.py
@@ -18,6 +18,12 @@ cxx_compiler_flags = []
 if os.name == 'nt':
     cxx_compiler_flags.append("/wd4624")
 
+_warn_suppress = []
+_nvcc_warn = []
+if os.name != 'nt':
+    _warn_suppress = ["-Wno-deprecated-declarations"]
+    _nvcc_warn = ["-Xcompiler=-Wno-deprecated-declarations"]
+
 setup(
     name="simple_knn",
     ext_modules=[
@@ -27,7 +33,10 @@ setup(
             "spatial.cu", 
             "simple_knn.cu",
             "ext.cpp"],
-            extra_compile_args={"nvcc": [], "cxx": cxx_compiler_flags})
+            extra_compile_args={
+                "nvcc": _nvcc_warn,
+                "cxx": _warn_suppress + cxx_compiler_flags,
+            })
         ],
     cmdclass={
         'build_ext': BuildExtension

--- a/submodules/simple-knn/spatial.cu
+++ b/submodules/simple-knn/spatial.cu
@@ -20,7 +20,7 @@ distCUDA2(const torch::Tensor& points)
   auto float_opts = points.options().dtype(torch::kFloat32);
   torch::Tensor means = torch::full({P}, 0.0, float_opts);
   
-  SimpleKNN::knn(P, (float3*)points.contiguous().data<float>(), means.contiguous().data<float>());
+  SimpleKNN::knn(P, (float3*)points.contiguous().data_ptr<float>(), means.contiguous().data_ptr<float>());
 
   return means;
 }

--- a/train_semantic.py
+++ b/train_semantic.py
@@ -8,6 +8,7 @@ from arguments import ModelParams, PipelineParams, OptimizationParams
 from spatial_track.spatialtrack import GausCluster
 from gaussian_renderer import render
 from scene import Scene, GaussianModel
+from scene.gaussian_model import _should_export_open3d_auxiliary_plys, _write_xyz_rgb_ply
 from utils.contrastive_utils import *
 from utils.general_mesh_utils import *
 from tqdm import tqdm
@@ -530,9 +531,21 @@ class SegSplatting:
         """Semantic feature training main loop: single-view contrast + multi-view contrast + 3D contrast."""
         print("\n\033[91mRunning Spatial Contrastive Learning... \033[0m")
 
-        if os.path.exists(
-                os.path.join(self.model_path, "point_cloud/iteration_{}".format(self.optimparams.iterations))):
+        # 僅以「最終匯出是否完成」為準：舊邏輯只判斷 iteration 目錄存在會誤跳過（例如僅有 scene.save 的 ply、
+        # 或後續 optimize 寫入的子目錄），導致從未執行 export_segment_results_final，因而沒有 instance_info.json。
+        final_iter_dir = os.path.join(
+            self.model_path, "point_cloud", "iteration_{}".format(self.optimparams.iterations)
+        )
+        export_marker = os.path.join(final_iter_dir, "instance_info.json")
+        if os.path.isfile(export_marker):
+            print(
+                f"Skip semantic feature training: found completed export {export_marker}"
+            )
             return
+        if os.path.isdir(final_iter_dir) and not os.path.isfile(export_marker):
+            print(
+                f"⚠️  目錄已存在但缺少 instance_info.json，將重新訓練並匯出: {final_iter_dir}"
+            )
 
         self.gaussians.training_setup(self.optimparams)
 
@@ -746,40 +759,60 @@ class SegSplatting:
         num_instances = int(self.Seg3D_masks.shape[1])
 
         instance_colors = self._deterministic_semantic_colors(num_instances)
-        
+
         # Write full colored point cloud + label array + separate point cloud for each instance
-        full_pcd = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(scene_pclds))
-        colors = np.zeros((total_points, 3))
-        
+        colors = np.zeros((total_points, 3), dtype=np.float32)
+
         final_labels_np = final_labels.numpy().astype(np.int32, copy=False)
         for i, label in enumerate(final_labels_np):
             if label < 0 or label >= num_instances:
                 colors[i] = [1.0, 1.0, 1.0]
             else:
                 colors[i] = instance_colors[label]
-                
-        full_pcd.colors = o3d.utility.Vector3dVector(colors)
-        
-        o3d.io.write_point_cloud(os.path.join(save_dir, "point_cloud_labels.ply"), full_pcd)
-        
+
+        ply_labels = os.path.join(save_dir, "point_cloud_labels.ply")
+        if _should_export_open3d_auxiliary_plys():
+            full_pcd = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(scene_pclds))
+            full_pcd.colors = o3d.utility.Vector3dVector(colors)
+            o3d.io.write_point_cloud(ply_labels, full_pcd)
+        else:
+            _write_xyz_rgb_ply(ply_labels, scene_pclds, colors)
+
         np.save(os.path.join(save_dir, "point_cloud_labels.npy"), final_labels_np)
-        
+
         save_partial_dir = os.path.join(save_dir, "label_pointclouds")
         os.makedirs(save_partial_dir, exist_ok=True)
         for new_label_id in range(num_instances):
             label_mask = final_labels == new_label_id
             if label_mask.sum() > 0:
                 label_positions = scene_pclds[label_mask.numpy()]
-                pcld = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(label_positions))
-                pcld.paint_uniform_color(instance_colors[new_label_id])
-                o3d.io.write_point_cloud(os.path.join(save_partial_dir, f"{new_label_id}.ply"), pcld)
-        
+                out_part = os.path.join(save_partial_dir, f"{new_label_id}.ply")
+                if _should_export_open3d_auxiliary_plys():
+                    pcld = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(label_positions))
+                    pcld.paint_uniform_color(instance_colors[new_label_id])
+                    o3d.io.write_point_cloud(out_part, pcld)
+                else:
+                    c = instance_colors[new_label_id]
+                    _write_xyz_rgb_ply(
+                        out_part,
+                        label_positions,
+                        np.broadcast_to(c, (label_positions.shape[0], 3)),
+                    )
+
         unassigned_label_mask = final_labels == -1
         if unassigned_label_mask.sum() > 0:
             unassigned_positions = scene_pclds[unassigned_label_mask.numpy()]
-            unassigned_pcld = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(unassigned_positions))
-            unassigned_pcld.paint_uniform_color([1.0, 1.0, 1.0])
-            o3d.io.write_point_cloud(os.path.join(save_partial_dir, "unassigned.ply"), unassigned_pcld)
+            out_un = os.path.join(save_partial_dir, "unassigned.ply")
+            if _should_export_open3d_auxiliary_plys():
+                unassigned_pcld = o3d.geometry.PointCloud(o3d.utility.Vector3dVector(unassigned_positions))
+                unassigned_pcld.paint_uniform_color([1.0, 1.0, 1.0])
+                o3d.io.write_point_cloud(out_un, unassigned_pcld)
+            else:
+                _write_xyz_rgb_ply(
+                    out_un,
+                    unassigned_positions,
+                    np.ones((unassigned_positions.shape[0], 3), dtype=np.float32),
+                )
 
         # ========== Save best view images for each instance ==========
         self._export_instance_images(save_dir, save_images_dir, num_instances)


### PR DESCRIPTION
- CUDA rasterization: include <cstdint>, setup.py warning flags for nvcc/PyTorch 2.10
- simple-knn: align spatial.cu and setup.py with aarch64 builds
- spatial_track: avoid Open3D SIGSEGV on DBSCAN path (sklearn + numpy); node returns numpy point cloud
- gaussian_model: skip Open3D auxiliary *_color/_feat PLY on aarch64 by default (SIMRECON_OPEN3D_AUX_PLY); add plyfile RGB export helper
- train_semantic: skip training only when instance_info.json exists; export colored PLYs via plyfile on aarch64; import ply helpers from gaussian_model
- infer_scene_graph: batch tqdm over frames; optional TextIteratorStreamer progress; max_new_tokens / no_stream_progress CLI; tqdm-safe logging